### PR TITLE
add support for fastboot

### DIFF
--- a/app/services/database-manager.js
+++ b/app/services/database-manager.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Pouch from 'pouchdb';
 import ENV from 'ember-api-docs/config/environment';
+import extend from 'lodash/object/extend';
 
 const Promise = Ember.RSVP.Promise;
 
@@ -37,15 +38,15 @@ export default Ember.Service.extend({
     const remote = this._remote;
     const local = this._local;
 
-    const pouchOptions = Ember.$.extend({}, options, {include_docs: true, keys: ids});
+    const pouchOptions = extend({}, options, {include_docs: true, keys: ids});
 
     return new Promise((resolve, reject) => {
       return local.allDocs(pouchOptions).then(documents => {
         const notFound = documents.rows.filter(doc => doc.error === 'not_found');
 
         if (notFound.length > 0) {
-          const remotePouchOptions = Ember.$.extend({include_docs: true}, pouchOptions);
-          return remote.allDocs(Ember.$.extend(remotePouchOptions, pouchOptions)).then((docs) => {
+          const remotePouchOptions = extend({include_docs: true}, pouchOptions);
+          return remote.allDocs(extend(remotePouchOptions, pouchOptions)).then((docs) => {
             const extractedDocs = extractDocuments(docs);
             return local.bulkDocs(extractedDocs.data, {new_edits: false});
           }).then(() => {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,7 +13,9 @@ module.exports = function(defaults) {
     }
   });
 
-  app.import(app.bowerDirectory + '/pouchdb/dist/pouchdb.memory.js');
+  if (!process.env.EMBER_CLI_FASTBOOT && process.env.EMBER_ENV === 'test') {
+    app.import(app.bowerDirectory + '/pouchdb/dist/pouchdb.memory.js');
+  }
 
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-bourbon": "1.1.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-fastboot": "0.3.1",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
@@ -38,8 +39,8 @@
     "ember-data": "git+https://github.com/emberjs/data#master",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-lodash": "0.0.5",
-    "ember-pouch": "^3.0.0",
+    "ember-lodash": "0.0.6",
+    "ember-pouch": "fivetanley/ember-pouch#fastboot-support",
     "ember-remarkable": "2.1.0",
     "emberx-select": "2.0.2"
   }


### PR DESCRIPTION
- switch to lodash as `Ember.$.extend` isn't available in fastboot.
- use custom ember pouch until we can battle test this and get it back
into the main addon