### PR TITLE
add some basic OpenGraph tags for max social

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
 
+const { set, inject } = Ember;
+
 export default Ember.Route.extend({
+  headData: inject.service(),
   title: function(tokens) {
     const reversed = Ember.makeArray(tokens).reverse();
-    return `${reversed.join(' - ')} - Ember API Documentation`;
+    const title = `${reversed.join(' - ')} - Ember API Documentation`;
+    set(this, 'headData.title', title);
+    return title;
   }
 });

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,5 @@
+<meta property="og:title" content={{model.title}} />
+<meta property="og:image" content="assets/images/ember-logo.jpg" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="1016" />
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1539,6 +1539,18 @@
       "from": "ember-cli-get-component-path-option@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz"
     },
+    "ember-cli-head": {
+      "version": "0.0.5",
+      "from": "ember-cli-head@latest",
+      "resolved": "https://registry.npmjs.org/ember-cli-head/-/ember-cli-head-0.0.5.tgz",
+      "dependencies": {
+        "fastboot-filter-initializers": {
+          "version": "0.0.1",
+          "from": "fastboot-filter-initializers@0.0.1",
+          "resolved": "https://registry.npmjs.org/fastboot-filter-initializers/-/fastboot-filter-initializers-0.0.1.tgz"
+        }
+      }
+    },
     "ember-cli-htmlbars": {
       "version": "1.0.3",
       "from": "ember-cli-htmlbars@>=1.0.1 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node_modules"
   ],
   "devDependencies": {
-    "ember-cli-document-title": "0.3.1"
+    "ember-cli-document-title": "0.3.1",
+    "ember-cli-head": "0.0.5"
   }
 }

--- a/tests/acceptance/open-graph-tags-test.js
+++ b/tests/acceptance/open-graph-tags-test.js
@@ -1,0 +1,31 @@
+import { test } from 'qunit';
+import $ from 'jquery';
+
+import moduleForAcceptance from 'ember-api-docs/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | open graph tags', {
+  beforeEach() {
+    return visit('/ember/1.0.0/classes/Container');
+  }
+});
+
+function findOpenGraphContent (propertyName) {
+  const el = $(`meta[property="og:${propertyName}"]`);
+  return el.attr('content');
+}
+
+test('assigns title property', function (assert) {
+  const title = findOpenGraphContent('title');
+  assert.equal(title, 'Container - 1.0.0 - Ember API Documentation');
+});
+
+test('assigns image property and width/height', function (assert) {
+  const image = findOpenGraphContent('image');
+  assert.equal(image, 'assets/images/ember-logo.jpg');
+
+  const imageWidth = findOpenGraphContent('image:width');
+  assert.equal(imageWidth, '1200');
+
+  const imageHeight = findOpenGraphContent('image:height');
+  assert.equal(imageHeight, '1016');
+});


### PR DESCRIPTION
Thanks to @ronco, we can just add some properties to a
`app/templates/head.hbs` template and they should be rendered on
Facebook and Twitter.

Here's the addon: https://github.com/ronco/ember-cli-head