### PR TITLE
[ENHANCEMENT] Adding an error page to handle 404 and other errors

### DIFF
--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function eq(params) {
+  return params[0] === params[1];
+}
+
+export default Ember.Helper.helper(eq);

--- a/app/styles/components/_all.scss
+++ b/app/styles/components/_all.scss
@@ -6,4 +6,5 @@
 @import "back-to-top";
 @import "highlight";
 @import "toc";
-@import "old-version-warning"
+@import "old-version-warning";
+@import "whoops";

--- a/app/styles/components/_whoops.scss
+++ b/app/styles/components/_whoops.scss
@@ -1,0 +1,8 @@
+.whoops {
+  width: 100%;
+
+  &__title {
+    text-transform: uppercase;
+  }
+
+}

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,0 +1,17 @@
+<article class="whoops">
+  {{#if (eq model.status 404)}}
+  <h2 class="whoops__title">
+    Ack! 404 friend, you're in the wrong place
+  </h2>
+  <div class="whoops__message">
+    <p>
+    This page wasn't found. Please try the {{#link-to 'index'}}API docs page{{/link-to}}.
+    If you expected something else to be here, please file a <a href="https://github.com/fivetanley/ember-api-docs/issues/new" target="_blank">ticket</a>.
+    </p>
+  </div>
+  {{else}}
+  <h2 class="whoops__title">
+   Whoops! Something went wrong.
+  </h2>
+  {{/if}}
+</article>

--- a/tests/unit/helpers/eq-test.js
+++ b/tests/unit/helpers/eq-test.js
@@ -1,0 +1,9 @@
+import { eq } from 'ember-api-docs/helpers/eq';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | eq');
+
+test('it works', function(assert) {
+  let result = eq([404, 404]);
+  assert.ok(result);
+});


### PR DESCRIPTION
The 404 page is similar to the ember website's content with a link to the official repo while the error content is a generic message. Both flows mentioned here use the same route.

Fixes #4 and #5. Here are some screenshots,
<img width="1680" alt="screenshot 2016-03-26 19 21 00" src="https://cloud.githubusercontent.com/assets/604117/14063510/be5a91aa-f389-11e5-887e-398a1d10f44e.png">
<img width="1680" alt="screenshot 2016-03-26 19 21 14" src="https://cloud.githubusercontent.com/assets/604117/14063511/be5ad2aa-f389-11e5-98a0-e2f44c2b342c.png">


