### PR TITLE
add loading spinner

### DIFF
--- a/app/components/loading-spinner.js
+++ b/app/components/loading-spinner.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['loading-spinner']
+});

--- a/app/styles/components/_all.scss
+++ b/app/styles/components/_all.scss
@@ -8,3 +8,4 @@
 @import "toc";
 @import "old-version-warning";
 @import "whoops";
+@import "loading-spinner";

--- a/app/styles/components/_loading-spinner.scss
+++ b/app/styles/components/_loading-spinner.scss
@@ -1,0 +1,91 @@
+.loading-spinner {
+  text-align: center;
+  margin: 5em auto;
+  .sk-folding-cube {
+    margin: 20px auto;
+    width: 40px;
+    height: 40px;
+    position: relative;
+    -webkit-transform: rotateZ(45deg);
+            transform: rotateZ(45deg);
+  }
+
+  .sk-folding-cube .sk-cube {
+    float: left;
+    width: 50%;
+    height: 50%;
+    position: relative;
+    -webkit-transform: scale(1.1);
+        -ms-transform: scale(1.1);
+            transform: scale(1.1);
+  }
+  .sk-folding-cube .sk-cube:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: $ember-orange;
+    -webkit-animation: sk-foldCubeAngle 2.4s infinite linear both;
+            animation: sk-foldCubeAngle 2.4s infinite linear both;
+    -webkit-transform-origin: 100% 100%;
+        -ms-transform-origin: 100% 100%;
+            transform-origin: 100% 100%;
+  }
+  .sk-folding-cube .sk-cube2 {
+    -webkit-transform: scale(1.1) rotateZ(90deg);
+            transform: scale(1.1) rotateZ(90deg);
+  }
+  .sk-folding-cube .sk-cube3 {
+    -webkit-transform: scale(1.1) rotateZ(180deg);
+            transform: scale(1.1) rotateZ(180deg);
+  }
+  .sk-folding-cube .sk-cube4 {
+    -webkit-transform: scale(1.1) rotateZ(270deg);
+            transform: scale(1.1) rotateZ(270deg);
+  }
+  .sk-folding-cube .sk-cube2:before {
+    -webkit-animation-delay: 0.3s;
+            animation-delay: 0.3s;
+  }
+  .sk-folding-cube .sk-cube3:before {
+    -webkit-animation-delay: 0.6s;
+            animation-delay: 0.6s;
+  }
+  .sk-folding-cube .sk-cube4:before {
+    -webkit-animation-delay: 0.9s;
+            animation-delay: 0.9s;
+  }
+  @-webkit-keyframes sk-foldCubeAngle {
+    0%, 10% {
+      -webkit-transform: perspective(140px) rotateX(-180deg);
+              transform: perspective(140px) rotateX(-180deg);
+      opacity: 0;
+    } 25%, 75% {
+      -webkit-transform: perspective(140px) rotateX(0deg);
+              transform: perspective(140px) rotateX(0deg);
+      opacity: 1;
+    } 90%, 100% {
+      -webkit-transform: perspective(140px) rotateY(180deg);
+              transform: perspective(140px) rotateY(180deg);
+      opacity: 0;
+    }
+  }
+
+  @keyframes sk-foldCubeAngle {
+    0%, 10% {
+      -webkit-transform: perspective(140px) rotateX(-180deg);
+              transform: perspective(140px) rotateX(-180deg);
+      opacity: 0;
+    } 25%, 75% {
+      -webkit-transform: perspective(140px) rotateX(0deg);
+              transform: perspective(140px) rotateX(0deg);
+      opacity: 1;
+    } 90%, 100% {
+      -webkit-transform: perspective(140px) rotateY(180deg);
+              transform: perspective(140px) rotateY(180deg);
+      opacity: 0;
+    }
+  }
+}

--- a/app/templates/components/loading-spinner.hbs
+++ b/app/templates/components/loading-spinner.hbs
@@ -1,0 +1,6 @@
+<div class="sk-folding-cube">
+  <div class="sk-cube1 sk-cube"></div>
+  <div class="sk-cube2 sk-cube"></div>
+  <div class="sk-cube4 sk-cube"></div>
+  <div class="sk-cube3 sk-cube"></div>
+</div>

--- a/app/templates/components/loading-spinner.hbs
+++ b/app/templates/components/loading-spinner.hbs
@@ -4,3 +4,4 @@
   <div class="sk-cube4 sk-cube"></div>
   <div class="sk-cube3 sk-cube"></div>
 </div>
+{{yield}}

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+{{loading-spinner}}

--- a/tests/integration/components/loading-spinner-test.js
+++ b/tests/integration/components/loading-spinner-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('loading-spinner', 'Integration | Component | loading spinner', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{loading-spinner}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#loading-spinner}}
+      template block text
+    {{/loading-spinner}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
![ember-docs-loading](https://cloud.githubusercontent.com/assets/1416421/14158329/63025524-f684-11e5-8bd6-a646f2773bba.gif)

This PR addresses https://github.com/fivetanley/ember-api-docs/issues/10

This is a first pass at adding a loading spinner. I chose the square-ish animation since it kind of matches the geometric background in the header. That said, if we decide to go for something more rounded instead, I'm fine with changing it... 



