### PR TITLE
Add projects section to sidebar

### DIFF
--- a/app/controllers/project-version.js
+++ b/app/controllers/project-version.js
@@ -22,5 +22,7 @@ export default Ember.Controller.extend({
       const b_ver = b.get('id').split("-")[1];
       return semverCompare(b_ver, a_ver);
     });
-  })
+  }),
+
+  activeProject: Ember.computed.alias('model.project.id')
 });

--- a/app/styles/components/_sidebar.scss
+++ b/app/styles/components/_sidebar.scss
@@ -22,6 +22,9 @@
   .select2 {
     margin-bottom: 1em;
   }
+  ol{
+    margin-bottom: 1.5em;
+  }
 }
 
 label[for="toc-toggle"] {
@@ -92,6 +95,10 @@ li.toc-level-0 {
 
     &:hover {
       color: $ember-orange;
+    }
+    &.active {
+      color: $ember-orange;
+      font-weight: bold;
     }
   }
 

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -2,8 +2,8 @@
   <ol class="toc-level-0">
     <li class="toc-level-0">Projects
       <ol class="toc-level-1 selected" style="display: block;">
-        <li class="toc-level-1">{{#link-to 'project' 'ember'}}Ember{{/link-to}}</li>
-        <li class="toc-level-1">{{#link-to 'project' 'ember-data'}}Ember Data{{/link-to}}</li>
+        <li class="toc-level-1">{{#link-to 'project' 'ember' active=(eq activeProject 'ember')}}Ember{{/link-to}}</li>
+        <li class="toc-level-1">{{#link-to 'project' 'ember-data' active=(eq activeProject 'ember-data')}}Ember Data{{/link-to}}</li>
       </ol>
     </li>
   </ol>

--- a/app/templates/project-version.hbs
+++ b/app/templates/project-version.hbs
@@ -1,19 +1,25 @@
 <aside class="sidebar">
-
-{{#x-select value=model action="updateProject" default=model.id project=model.project class="spec-versions-box"}}
-  {{#each projectVersions as |projectVersion|}}
-    {{#x-option value=projectVersion}}{{projectVersion.version}}{{/x-option}}
-  {{/each}}
-{{/x-select}}
-<ol class="toc-level-0">
-  <li class="toc-level-0">Classes
-    <ol class="toc-level-1 selected" style="display: block;">
-      {{#each classesIDs as |classID|}}
-        <li class="toc-level-1">{{#link-to 'project-version.class' model.version classID}}{{classID}}{{/link-to}}</li>
-      {{/each}}
-    </ol>
-  </li>
-</ol>
+  <ol class="toc-level-0">
+    <li class="toc-level-0">Projects
+      <ol class="toc-level-1 selected" style="display: block;">
+        <li class="toc-level-1">{{#link-to 'project' 'ember'}}Ember{{/link-to}}</li>
+        <li class="toc-level-1">{{#link-to 'project' 'ember-data'}}Ember Data{{/link-to}}</li>
+      </ol>
+    </li>
+  </ol>
+  {{#x-select value=model action="updateProject" default=model.id project=model.project class="spec-versions-box"}}
+    {{#each projectVersions as |projectVersion|}}
+      {{#x-option value=projectVersion}}{{projectVersion.version}}{{/x-option}}
+    {{/each}}
+  {{/x-select}}
+  <ol class="toc-level-0">
+    <li class="toc-level-0">Classes
+      <ol class="toc-level-1 selected" style="display: block;">
+        {{#each classesIDs as |classID|}}
+          <li class="toc-level-1">{{#link-to 'project-version.class' model.version classID}}{{classID}}{{/link-to}}</li>
+        {{/each}}
+      </ol>
+    </li>
+  </ol>
 </aside>
-
 {{outlet}}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "ember-browserify": "1.1.8",
     "ember-cli-document-title": "0.3.1",
     "ember-cli-head": "0.0.5",
-    "ember-composable-helpers": "0.20.0"
+    "ember-composable-helpers": "0.20.0",
+    "ember-truth-helpers": "1.2.0"
   },
   "fastbootDependencies": [
     "redisdown"


### PR DESCRIPTION
<img width="561" alt="screen shot 2016-03-30 at 4 16 28 pm" src="https://cloud.githubusercontent.com/assets/1416421/14160737/45f28724-f693-11e5-9391-33e01d2256dc.png">

Adds the sections for Ember and Ember Data to the documentation sidebar. Takes care of https://github.com/fivetanley/ember-api-docs/issues/7